### PR TITLE
Update HTML parsing to extract_html_bs4

### DIFF
--- a/sthir/scan.py
+++ b/sthir/scan.py
@@ -41,7 +41,7 @@ def generate_bloom_filter(file,
     This method is internally used in method - create_search_page
     """
     spectral = spectral_bloom_filter.Spectral_Bloom_Filter()
-    tokens = parse.extract_html_newspaper(file,
+    tokens = parse.extract_html_bs4(file,
                                           remove_stopwords=remove_stopwords)
 
     title = lxml.html.parse(file).find(".//title").text


### PR DESCRIPTION
I am having issues with `extract_html_newspaper`, our default parsing technique which relies on Newspaper3k. At times, it will not find any text and return the number of tokens as zero. This further causes the `optimal_m_k` method to crash as n becomes zero.
Moving to `extract_html_bs4` works for now.